### PR TITLE
Golang 1.19 support and tests using 1.18

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -5,7 +5,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x, 1.19.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run's Golint 
         run: |
-            export PATH=$PATH:$(go env GOPATH)/bin
+            # export PATH=$PATH:$(go env GOPATH)/bin
             go get -u golang.org/x/lint/golint
             golint -set_exit_status ./...
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -5,7 +5,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x, 1.19.x]
+        go-version: [1.17.x,1.18.x,1.19.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,7 +2,36 @@ name: 'cassler ci'
 on:
   push:
 jobs:
+
+  go-lint:
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: setup GOPATH into PATH
+        run: |
+          echo "::set-env name=GOPATH::$(go env GOPATH)"
+          echo "::add-path::$(go env GOPATH)/bin"
+        shell: bash
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true  
+
+      - uses: actions/checkout@v2
+
+      - name: Run's Golint 
+        run: |
+            export PATH=$PATH:$(go env GOPATH)/bin
+            go get -u golang.org/x/lint/golint
+            golint -set_exit_status ./...
+
   unit-test:
+    needs: [ go-lint ]
     strategy:
       matrix:
         go-version: [1.17.x,1.18.x,1.19.x]
@@ -26,12 +55,6 @@ jobs:
 
       - name: Install dependencies
         run: go get -u 
-
-      - name: Run's Golint 
-        run: |
-            # export PATH=$PATH:$(go env GOPATH)/bin
-            go get -u golang.org/x/lint/golint
-            golint -set_exit_status ./...
 
       - name: Test
         run: go test -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.19
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15 AS builder
+FROM golang:1.19 AS builder
 
 WORKDIR $GOPATH/src/cassler
 
@@ -12,7 +12,5 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cassler .
 FROM scratch
 
 COPY --from=builder /go/src/cassler/cassler ./
-
-EXPOSE 8080
 
 ENTRYPOINT ["./cassler"]


### PR DESCRIPTION
* Cassler build packages using golang 1.19 version 
* Docker build for golang 1.19 version
* Retrocompatibility Tests using 1.18 and 1.19 
* Removing 1.15.x, 1.16.x compatibility